### PR TITLE
Add new IPs for the BYOD VPN profile to the allowlist

### DIFF
--- a/nginx.conf.orig
+++ b/nginx.conf.orig
@@ -49,9 +49,11 @@ http {
   <% if ENV.fetch("CF_SPACE") != 'production' %>
     satisfy any;
     allow 85.133.67.244/32;  # office ip Disaster Recovery VPN
+    allow 213.86.153.211/32; # office ip BYOD VPN
     allow 213.86.153.212/32; # office ip WC
     allow 213.86.153.213/32; # office ip WC
     allow 213.86.153.214/32; # office ip VPN
+    allow 213.86.153.231/32; # office ip BYOD VPN
     allow 213.86.153.235/32; # office ip WC
     allow 213.86.153.236/32; # office ip WC
     allow 213.86.153.237/32; # office ip VPN


### PR DESCRIPTION
Copying from slack announcement:

> This will mean the BYOD VPN will have separate public IP's to the VPN
profile used by managed GDS macOS devices